### PR TITLE
[Chore] setting up prometheus metrics config and flags

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -780,6 +780,12 @@ var (
 		Value: metrics.DefaultConfig.InfluxDBOrganization,
 	}
 
+	MetricsPrometheusEndpointFlag = cli.StringFlag{
+		Name:  "metrics.prometheus.endpoint",
+		Usage: "Prometheus API endpoint to report metrics to",
+		Value: metrics.DefaultConfig.PrometheusEndpointPort,
+	}
+
 	CatalystFlag = cli.BoolFlag{
 		Name:  "catalyst",
 		Usage: "Catalyst mode (eth2 integration testing)",

--- a/metrics/config.go
+++ b/metrics/config.go
@@ -33,6 +33,8 @@ type Config struct {
 	InfluxDBToken        string `toml:",omitempty"`
 	InfluxDBBucket       string `toml:",omitempty"`
 	InfluxDBOrganization string `toml:",omitempty"`
+
+	PrometheusEndpointPort string  `toml:",omitempty"`
 }
 
 // DefaultConfig is the default config for metrics used in go-ethereum.
@@ -53,4 +55,7 @@ var DefaultConfig = Config{
 	InfluxDBToken:        "test",
 	InfluxDBBucket:       "geth",
 	InfluxDBOrganization: "geth",
+
+	// prometheus flag
+	PrometheusEndpointPort: ":19090",
 }


### PR DESCRIPTION
This PR sets prometheus metrics config flag
### Checklist:
- [x] Initiate prometheus metrics config flag in `cmd/utils` package